### PR TITLE
쿼리 메서드 기능

### DIFF
--- a/src/main/java/study/jpadata/entity/Member.java
+++ b/src/main/java/study/jpadata/entity/Member.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedQuery;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,6 +22,10 @@ import lombok.ToString;
 @NamedQuery(
     name = "Member.findByUsername",
     query = "select m from Member m where m.name = :username"
+)
+@NamedEntityGraph(
+    name = "Member.all",
+    attributeNodes = @NamedAttributeNode("team")
 )
 public class Member {
     @Id @GeneratedValue

--- a/src/main/java/study/jpadata/entity/Member.java
+++ b/src/main/java/study/jpadata/entity/Member.java
@@ -53,6 +53,10 @@ public class Member {
         this.team = team;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public void changeTeam(Team team) {
         if (this.team != null) {
             this.team.getMembers().remove(this);

--- a/src/main/java/study/jpadata/entity/Member.java
+++ b/src/main/java/study/jpadata/entity/Member.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,10 @@ import lombok.ToString;
 @Getter
 @ToString(of = {"id", "name", "age"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NamedQuery(
+    name = "Member.findByUsername",
+    query = "select m from Member m where m.name = :username"
+)
 public class Member {
     @Id @GeneratedValue
     @Column(name = "member_id")

--- a/src/main/java/study/jpadata/repository/MemberDto.java
+++ b/src/main/java/study/jpadata/repository/MemberDto.java
@@ -1,0 +1,18 @@
+package study.jpadata.repository;
+
+import lombok.Data;
+
+@Data
+public class MemberDto {
+    private Long id;
+    private String username;
+    private int age;
+    private String teamName;
+
+    public MemberDto(Long id, String username, int age, String teamName) {
+        this.id = id;
+        this.username = username;
+        this.age = age;
+        this.teamName = teamName;
+    }
+}

--- a/src/main/java/study/jpadata/repository/MemberJpaRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberJpaRepository.java
@@ -49,4 +49,10 @@ public class MemberJpaRepository {
             .setParameter("age", age)
             .getResultList();
     }
+
+    public List<Member> findByUsername(String username) {
+        return em.createNamedQuery("Member.findByUsername", Member.class)
+            .setParameter("username", username)
+            .getResultList();
+    }
 }

--- a/src/main/java/study/jpadata/repository/MemberJpaRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberJpaRepository.java
@@ -41,4 +41,12 @@ public class MemberJpaRepository {
     public Member find(Long id) {
         return em.find(Member.class, id);
     }
+
+    public List<Member> findByUsernameAndAgeGreaterThan(String username, int age) {
+        return em.createQuery("select m from Member m" + 
+            " where m.name = :username and m.age > :age", Member.class)
+            .setParameter("username", username)
+            .setParameter("age", age)
+            .getResultList();
+    }
 }

--- a/src/main/java/study/jpadata/repository/MemberJpaRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberJpaRepository.java
@@ -55,4 +55,18 @@ public class MemberJpaRepository {
             .setParameter("username", username)
             .getResultList();
     }
+
+    public List<Member> findByPage(int age, int offset, int limit) {
+        return em.createQuery("select m from Member m where m.age = :age order by m.name desc", Member.class)
+            .setParameter("age", age)
+            .setFirstResult(offset)
+            .setMaxResults(limit)
+            .getResultList();
+    }
+
+    public long totalCount(int age) {
+        return em.createQuery("select count(m) from Member m where m.age = :age", Long.class)
+            .setParameter("age", age)
+            .getSingleResult();
+    }
 }

--- a/src/main/java/study/jpadata/repository/MemberJpaRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberJpaRepository.java
@@ -69,4 +69,10 @@ public class MemberJpaRepository {
             .setParameter("age", age)
             .getSingleResult();
     }
+
+    public int bulkAgeIncr(int age) {
+        return em.createQuery("update Member m set m.age = m.age + 1 where m.age >= :age")
+            .setParameter("age", age)
+            .executeUpdate();
+    }
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -28,4 +28,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // DTO 조회
     @Query("select new study.jpadata.repository.MemberDto(m.id, m.name, m.age, t.name) from Member m join m.team t")
     public List<MemberDto> findMemberDtoList();
+
+    @Query("select m from Member m where m.name in :names")
+    public List<Member> findByNames(@Param("names") List<String> names);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -40,4 +41,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update Member m set m.age = m.age + 1 where m.age >= :age")
     public int bulkIncrAge(@Param("age") int age);
+
+    @EntityGraph(attributePaths = {"team"})
+    public List<Member> findEntityGraphByName(String name);
+
+    @EntityGraph("Member.all")
+    public List<Member> findNamedEntityGraphByName(String name);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -3,10 +3,15 @@ package study.jpadata.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import study.jpadata.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     
     public List<Member> findByNameAndAgeGreaterThan(String name, int age);
+
+    @Query(name = "Member.findByUsername")
+    public List<Member> findByUsername(@Param("username") String username);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -14,4 +14,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query(name = "Member.findByUsername")
     public List<Member> findByUsername(@Param("username") String username);
+
+    @Query("select m from Member m where m.name = :username and m.age > :age")
+    public List<Member> findUserCustomQuery(
+        @Param("username") String username,
+        @Param("age") int age
+    );
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -8,8 +8,10 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.QueryHint;
 import study.jpadata.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -47,4 +49,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @EntityGraph("Member.all")
     public List<Member> findNamedEntityGraphByName(String name);
+
+    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
+    public Member findReadOnlyByName(String name);
+
+    @QueryHints(
+        value = {@QueryHint(name = "org.hibernate.readOnly", value = "true")},
+        forCounting = true
+    )
+Page<Member> findByUsername(String name, Pageable pageable);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -20,4 +20,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         @Param("username") String username,
         @Param("age") int age
     );
+
+    // 값 조회
+    @Query("select m.name from Member m")
+    public List<String> findUsernameList();
+
+    // DTO 조회
+    @Query("select new study.jpadata.repository.MemberDto(m.id, m.name, m.age, t.name) from Member m join m.team t")
+    public List<MemberDto> findMemberDtoList();
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +36,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     public List<Member> findByNames(@Param("names") List<String> names);
 
     public Page<Member> findByAge(int age, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Member m set m.age = m.age + 1 where m.age >= :age")
+    public int bulkIncrAge(@Param("age") int age);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -1,9 +1,12 @@
 package study.jpadata.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import study.jpadata.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     
+    public List<Member> findByNameAndAgeGreaterThan(String name, int age);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package study.jpadata.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,4 +33,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("select m from Member m where m.name in :names")
     public List<Member> findByNames(@Param("names") List<String> names);
+
+    public Page<Member> findByAge(int age, Pageable pageable);
 }

--- a/src/test/java/resources/application.yml
+++ b/src/test/java/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+      format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.type: trace

--- a/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
@@ -82,4 +82,20 @@ public class MemberJpaRepositoryTest {
             Assertions.assertTrue(m.getAge() > 5);
         });
     }
+
+    @Test
+    public void testFindByUsername() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member2", 13),
+            new Member("member3", 21)
+        ));
+        members.forEach(m -> memberJpaRepository.save(m));
+
+        List<Member> findMembers = memberJpaRepository.findByUsername("member2");
+
+        Assertions.assertEquals(1, findMembers.size());
+        Assertions.assertEquals("member2", findMembers.get(0).getName());
+        Assertions.assertEquals(13, findMembers.get(0).getAge());
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
@@ -118,4 +118,18 @@ public class MemberJpaRepositoryTest {
         Assertions.assertEquals(3, findMembers.size());
         Assertions.assertEquals(5, totalCount);
     }
+
+    @Test
+    public void testBulkAgeIncr() {
+        //given
+        memberJpaRepository.save(new Member("member1", 10));
+        memberJpaRepository.save(new Member("member2", 19));
+        memberJpaRepository.save(new Member("member3", 20));
+        memberJpaRepository.save(new Member("member4", 21));
+        memberJpaRepository.save(new Member("member5", 40));
+
+        int resultCount = memberJpaRepository.bulkAgeIncr(20);
+
+        Assertions.assertEquals(3, resultCount);
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
@@ -1,8 +1,10 @@
 package study.jpadata.repository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,9 +26,13 @@ public class MemberJpaRepositoryTest {
 
         Member findMember = memberJpaRepository.find(savedMember.getId());
 
-        Assertions.assertThat(findMember.getId()).isEqualTo(member.getId());
-        Assertions.assertThat(findMember.getName()).isEqualTo(member.getName());
-        Assertions.assertThat(findMember).isEqualTo(member);
+        // Assertions.assertThat(findMember.getId()).isEqualTo(member.getId());
+        // Assertions.assertThat(findMember.getName()).isEqualTo(member.getName());
+        // Assertions.assertThat(findMember).isEqualTo(member);
+
+        Assertions.assertEquals(findMember.getId(), member.getId());
+        Assertions.assertEquals(findMember.getName(), member.getName());
+        Assertions.assertSame(findMember, member);
     }
 
     @Test
@@ -40,21 +46,40 @@ public class MemberJpaRepositoryTest {
         //단건 조회 검증
         Member findMember1 = memberJpaRepository.findById(member1.getId()).get();
         Member findMember2 = memberJpaRepository.findById(member2.getId()).get();
-        Assertions.assertThat(findMember1).isEqualTo(member1);
-        Assertions.assertThat(findMember2).isEqualTo(member2);
+        Assertions.assertSame(findMember1, member1);
+        Assertions.assertSame(findMember2, member2);
         
         //리스트 조회 검증
         List<Member> all = memberJpaRepository.findAll();
-        Assertions.assertThat(all.size()).isEqualTo(2);
+        Assertions.assertEquals(all.size(), 2);
         
         //카운트 검증
         long count = memberJpaRepository.count();
-        Assertions.assertThat(count).isEqualTo(2);
+        Assertions.assertEquals(count, 2);
         
         //삭제 검증
         memberJpaRepository.delete(member1);
         memberJpaRepository.delete(member2);
         long deletedCount = memberJpaRepository.count();
-        Assertions.assertThat(deletedCount).isEqualTo(0);
+        Assertions.assertEquals(0, deletedCount);
+    }
+
+    @Test
+    public void testFindByUsernameAndAgeGreaterThan() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member1", 13),
+            new Member("member2", 21),
+            new Member("member2", 16),
+            new Member("member3", 25)
+        ));
+        members.forEach(m -> memberJpaRepository.save(m));
+
+        List<Member> findMembers1 = memberJpaRepository.findByUsernameAndAgeGreaterThan("member1", 5);
+        Assertions.assertEquals(findMembers1.size(), 2);
+        findMembers1.forEach(m -> {
+            Assertions.assertEquals(m.getName(), "member1");
+            Assertions.assertTrue(m.getAge() > 5);
+        });
     }
 }

--- a/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberJpaRepositoryTest.java
@@ -98,4 +98,24 @@ public class MemberJpaRepositoryTest {
         Assertions.assertEquals("member2", findMembers.get(0).getName());
         Assertions.assertEquals(13, findMembers.get(0).getAge());
     }
+
+    @Test
+    public void testFindByPage() {
+        //given
+        memberJpaRepository.save(new Member("member1", 10));
+        memberJpaRepository.save(new Member("member2", 10));
+        memberJpaRepository.save(new Member("member3", 10));
+        memberJpaRepository.save(new Member("member4", 10));
+        memberJpaRepository.save(new Member("member5", 10));
+        
+        int age = 10;
+        int offset = 0;
+        int limit = 3;
+
+        List<Member> findMembers = memberJpaRepository.findByPage(age, offset, limit);
+        long totalCount = memberJpaRepository.totalCount(age);
+
+        Assertions.assertEquals(3, findMembers.size());
+        Assertions.assertEquals(5, totalCount);
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -95,4 +95,22 @@ public class MemberRepositoryTest {
         assertEquals("member2", findMembers.get(0).getName());
         assertEquals(13, findMembers.get(0).getAge());
     }
+
+    @Test
+    public void testCustomQuery() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member1", 13),
+            new Member("member2", 21),
+            new Member("member2", 16),
+            new Member("member3", 25)
+        ));
+        members.forEach(m -> memberRepository.save(m));
+
+        List<Member> findMembers = memberRepository.findUserCustomQuery("member2", 20);
+
+        assertEquals(1, findMembers.size());
+        assertEquals("member2", findMembers.get(0).getName());
+        assertEquals(21, findMembers.get(0).getAge());
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package study.jpadata.repository;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.transaction.Transactional;
 import study.jpadata.entity.Member;
+import study.jpadata.entity.Team;
 
 @SpringBootTest
 @Transactional
@@ -21,6 +23,9 @@ public class MemberRepositoryTest {
     
     @Autowired
     private MemberRepository memberRepository;
+    
+    @Autowired
+    private TeamRepository teamRepository;
 
     @Test
     public void testMember() {
@@ -112,5 +117,40 @@ public class MemberRepositoryTest {
         assertEquals(1, findMembers.size());
         assertEquals("member2", findMembers.get(0).getName());
         assertEquals(21, findMembers.get(0).getAge());
+    }
+
+    @Test
+    public void testFindUsernameList() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member2", 13),
+            new Member("member3", 21),
+            new Member("member4", 16),
+            new Member("member5", 25)
+        ));
+        members.forEach(m -> memberRepository.save(m));
+
+        List<String> memberUsernames = memberRepository.findUsernameList();
+
+        assertArrayEquals(
+            new String[]{"member1", "member2", "member3", "member4", "member5"},
+            memberUsernames.toArray()
+        );
+    }
+
+    @Test
+    public void testFindMemberDtoList() {
+        Team team = new Team("team1");
+        teamRepository.save(team);
+
+        Member member = new Member("member1", 20, team);
+        memberRepository.save(member);
+
+        List<MemberDto> findMemberDtoList = memberRepository.findMemberDtoList();
+
+        assertEquals(1, findMemberDtoList.size());
+        assertEquals("member1", findMemberDtoList.get(0).getUsername());
+        assertEquals(20, findMemberDtoList.get(0).getAge());
+        assertEquals("team1", findMemberDtoList.get(0).getTeamName());
     }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -1,5 +1,10 @@
 package study.jpadata.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -54,5 +59,24 @@ public class MemberRepositoryTest {
         memberRepository.delete(member2);
         long deletedCount = memberRepository.count();
         Assertions.assertThat(deletedCount).isEqualTo(0);
+    }
+
+    @Test
+    public void testFindByUsernameAndAgeGreaterThan() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member1", 13),
+            new Member("member2", 21),
+            new Member("member2", 16),
+            new Member("member3", 25)
+        ));
+        members.forEach(m -> memberRepository.save(m));
+
+        List<Member> findMembers1 = memberRepository.findByNameAndAgeGreaterThan("member1", 5);
+        assertEquals(findMembers1.size(), 2);
+        findMembers1.forEach(m -> {
+            assertEquals(m.getName(), "member1");
+            assertTrue(m.getAge() > 5);
+        });
     }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -193,4 +193,18 @@ public class MemberRepositoryTest {
         assertTrue(pagedMembers.isFirst());
         assertTrue(pagedMembers.hasNext());
     }
+
+    @Test
+    public void testBulkIncrAge() {
+        //given
+        memberRepository.save(new Member("member1", 10));
+        memberRepository.save(new Member("member2", 19));
+        memberRepository.save(new Member("member3", 20));
+        memberRepository.save(new Member("member4", 21));
+        memberRepository.save(new Member("member5", 40));
+
+        int resultCount = memberRepository.bulkIncrAge(20);
+
+        assertEquals(3, resultCount);
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -153,4 +153,20 @@ public class MemberRepositoryTest {
         assertEquals(20, findMemberDtoList.get(0).getAge());
         assertEquals("team1", findMemberDtoList.get(0).getTeamName());
     }
+
+    @Test
+    public void testFindByNames() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member1", 13),
+            new Member("member2", 21),
+            new Member("member2", 16),
+            new Member("member3", 25)
+        ));
+        members.forEach(m -> memberRepository.save(m));
+        
+        List<Member> findMembers = memberRepository.findByNames(List.of("member2", "member3"));
+
+        assertEquals(3, findMembers.size());
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -207,4 +207,44 @@ public class MemberRepositoryTest {
 
         assertEquals(3, resultCount);
     }
+
+    @Test
+    public void testFindEntityGraphByName() {
+        Team team1 = new Team("team1");
+        Team team2 = new Team("team2");
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+        
+        //given
+        memberRepository.save(new Member("member1", 10, team1));
+        memberRepository.save(new Member("member1", 19, team1));
+        memberRepository.save(new Member("member2", 20, team2));
+        memberRepository.save(new Member("member2", 21, team2));
+        memberRepository.save(new Member("member3", 40, team2));
+
+        List<Member> findMembers = memberRepository.findEntityGraphByName("member1");
+
+        assertEquals(2, findMembers.size());
+        findMembers.forEach(m -> assertEquals(m.getTeam(), team1));
+    }
+
+    @Test
+    public void testFindNamedEntityGraphByName() {
+        Team team1 = new Team("team1");
+        Team team2 = new Team("team2");
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+        
+        //given
+        memberRepository.save(new Member("member1", 10, team1));
+        memberRepository.save(new Member("member1", 19, team1));
+        memberRepository.save(new Member("member2", 20, team2));
+        memberRepository.save(new Member("member2", 21, team2));
+        memberRepository.save(new Member("member3", 40, team2));
+
+        List<Member> findMembers = memberRepository.findNamedEntityGraphByName("member2");
+
+        assertEquals(2, findMembers.size());
+        findMembers.forEach(m -> assertEquals(m.getTeam(), team2));
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -79,4 +79,20 @@ public class MemberRepositoryTest {
             assertTrue(m.getAge() > 5);
         });
     }
+
+    @Test
+    public void testFindByUsername() {
+        List<Member> members = new ArrayList<>(Arrays.asList(
+            new Member("member1", 10),
+            new Member("member2", 13),
+            new Member("member3", 21)
+        ));
+        members.forEach(m -> memberRepository.save(m));
+
+        List<Member> findMembers = memberRepository.findByUsername("member2");
+
+        assertEquals(1, findMembers.size());
+        assertEquals("member2", findMembers.get(0).getName());
+        assertEquals(13, findMembers.get(0).getAge());
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -12,6 +12,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import jakarta.transaction.Transactional;
 import study.jpadata.entity.Member;
@@ -168,5 +171,26 @@ public class MemberRepositoryTest {
         List<Member> findMembers = memberRepository.findByNames(List.of("member2", "member3"));
 
         assertEquals(3, findMembers.size());
+    }
+
+    @Test
+    public void testPaging() {
+        //given
+        memberRepository.save(new Member("member1", 10));
+        memberRepository.save(new Member("member2", 10));
+        memberRepository.save(new Member("member3", 10));
+        memberRepository.save(new Member("member4", 10));
+        memberRepository.save(new Member("member5", 10));
+        
+        PageRequest pageRequest = PageRequest.of(0, 3, Sort.by(Sort.Direction.DESC, "name"));
+        Page<Member> pagedMembers = memberRepository.findByAge(10, pageRequest);
+
+        List<Member> content = pagedMembers.getContent();
+        assertEquals(3, content.size());
+        assertEquals(5, pagedMembers.getTotalElements());
+        assertEquals(0, pagedMembers.getNumber());
+        assertEquals(2, pagedMembers.getTotalPages());
+        assertTrue(pagedMembers.isFirst());
+        assertTrue(pagedMembers.hasNext());
     }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import study.jpadata.entity.Member;
 import study.jpadata.entity.Team;
@@ -29,6 +30,9 @@ public class MemberRepositoryTest {
     
     @Autowired
     private TeamRepository teamRepository;
+
+    @Autowired
+    private EntityManager em;
 
     @Test
     public void testMember() {
@@ -246,5 +250,17 @@ public class MemberRepositoryTest {
 
         assertEquals(2, findMembers.size());
         findMembers.forEach(m -> assertEquals(m.getTeam(), team2));
+    }
+
+    @Test
+    public void queryHint() throws Exception {
+        //given
+        memberRepository.save(new Member("member1", 10));
+        em.flush();
+        em.clear();
+        //when
+        Member member = memberRepository.findReadOnlyByName("member1");
+        member.setName("member2");
+        em.flush(); //Update Query 실행X
     }
 }


### PR DESCRIPTION
### 메서드 이름으로 쿼리 생성
```java
public interface MemberRepository extends JpaRepository<Member, Long> {
    List<Member> findByUsernameAndAgeGreaterThan(String username, int age);
}
```
메서드 이름에 들어간 키워드를 통해 쿼리를 자동으로 생성해준다.
간단한건 사용하면 편리하다.

주의 할 점: 엔티티 필드명이 변경되면 그에 따라 메서드 이름도 적적히 변경해주어야 한다.

### `@NamedQuery`
NamedQuery 를 정의하고 이름을 통해 사용

```java
@Entity
@NamedQuery(
    name="Member.findByUsername",
    query="select m from Member m where m.username = :username")
public class Member {
...
}
```

`@Query` 를 생략하고 메서드 이름만으로 Named 쿼리를 호출할 수 있다.
* 스프링 데이터 JPA는 선언한 "도메인 클래스 + .(점) + 메서드 이름"으로 Named 쿼리를 찾아서 실행
* 만약 실행할 Named 쿼리가 없으면 메서드 이름으로 쿼리 생성 전략을 사용한다.
* 필요하면 전략을 변경할 수 있지만 권장하지 않는다.

스프링 데이터 JPA를 사용하면 실무에서 Named Query를 직접 등록해서 사용하는 일은 드물다. 대신 `@Query` 를 사용해서 리파지토리 메소드에 쿼리를 직접 정의한다.

### `@Query`: 메서드에 쿼리 직접 정의하기
`@Query` 를 이용하여 실행될 쿼리문을 직접 정의 할 수 있다.

* JPA Named 쿼리처럼 애플리케이션 실행 시점에 문법 오류를 발견할 수 있음(매우 큰 장점!)
* 메소드 이름으로 쿼리 생성은 파라미터가 증가하면서 메서드 이름이 매우 지저분져서 `@Query` 기능을 유용하게 사용 할 수 있다.

### @Query 사용해서 값 과 DTO 로 바로 조회하기
쿼리문에서 값을 바로 뽑아오거나 DTO 로 가져오게 할 수 있다. 이때 메서드 리턴 타입을 알맞게 변경해준다.

### 파라미터 바인딩
위치 기반과 이름 기반 바인딩이 제공 되는데 되도록 이름 기반 바인딩을 사용하도록 하자. 
위치 기반은 새로운 파라미터가 추가 되어서 순서가 바뀌게 되면 수정해야 할 코드가 많아지고 버그로 이어질 수 있다.

파라미터 바인딩은 컬랙션도 사용가능하다. 이때 `in` 절을 사용할 수 있다.
```java
@Query("select m from Member m where m.username in :names")
List<Member> findByNames(@Param("names") List<String> names);
```

### 반환 타입
상황에 따라 메서드 반환 타입을 변경/지정 해줄 수 있다.
* 컬랙션 : List<Member>
* 단건 : Member
* 단건 optional : Optional<Member>

컬랙션 반환 타입
* 조회 결과 하나 이상 -> 예상대로 컬랙션으로 리턴
* 조회 결과 없음 ->  빈 컬랙션

단건 반환 타입
* 조회 결과 하나 이상 -> 예외 발생
* 조회 결과 하나 -> 예상대로 리턴
* 조회 결과 없음 ->  null

단건 조회는 JPQL 의 getSingleResult() 가 호출이 된다. 결과가 없으면 `javax.persistence.NoResultException` 예외가 발생하는데 스프링 데이터 JPA 는 편리하게 이걸 catch 해서 null 을 반환해준다.

### 바닐라 JPA 페이징과 정렬
`offset` 과 `limit` 을 인자로 받아서 `setFirstResults()` 와 `setMaxResults()` 를 사용해서 구현한다.
이때 total count 를 구하기 위한 쿼리 메서드를 따로 구현하고 필요에 따라 같이 사용해야한다.

### 스프링 데이터 JPA 페이징과 정렬
메서드 파라미터에 `Sort`와  `Pageable` 등을 포함시키면 스프링 데이터 JPA 가 기능을 구현해준다.

반환 타입으로는 
* Page - 가져온 데이터와 더불어 데이터의 페이지 관련 데이터도 포함한다.
* Slice - Page 와 거의 동일하지만 total count 쿼리및 값을 생략한다.
* List - 페이징 정보 없이 가져온 데이터만 반환한다.

이런식으로 인터페이스 안에 메서드를 정의해 두고
```java
Page<Member> findByAge(int age, Pageable pageable);
```

`PageRequest` 객체를 넘겨서 호출할 수 있다.
```java
PageRequest pageRequest = PageRequest.of(0, 3, Sort.by(Sort.Direction.DESC, "username"));
Page<Member> page = memberRepository.findByAge(10, pageRequest);
```

보통 일반적으로 본 쿼리를 기반으로 사용해서 카운트 쿼리를 날려 total count 값을 가져오는데 성능에 문제가 될 수 있기 때문에 카운트 쿼리를 명시적으로 정의 해줄 수 있다.

```java
@Query(value = "select m from Member m",
    countQuery = "select count(m.username) from Member m")
Page<Member> findMemberAllCountBy(Pageable pageable);
```

DTO 로 변환해주기 위해서 `.map` 메서드를 사용할 수 있다. 이렇게 하면 `Page` 객체를 유지 할 수 있다.

```java
Page<Member> page = memberRepository.findByAge(10, pageRequest);
Page<MemberDto> dtoPage = page.map(m -> new MemberDto());
```

### 벌크성 수정 쿼리
수정 쿼리도 일발 쿼리랑 크게 다르지 않게 `@Query` 를 사용해서 수정 쿼리문을 만들어 줄 수 있다. 이때 `@Modifying` 애노테이션을 꼭 붙여주자. 그렇지 못 하면 예외가 발생한다.

벌크성 수정 쿼리는  영속성 컨텍스트에 반영이 되지 않아서 수정후 객체로 추가 작업을 진행할 경우, 컨텍스트를 수동으로 초기화 해주거나 아니면 `@Modifying` 에 `clearAutomatically = true` 옵션을 넘겨주자.

### `@EntityGraph`
`@Query` 를 통해 추가적으로 쿼리문 명시 없이 `join fetch` 를 쓰고 싶을때 `@EntityGraph` 쓴다.
```java
@EntityGraph(attributePaths = {"team"})
```

간단할 때는 `@EntityGraph` 사용하고 좀 복잡해지면 그냥 JPQL 에서 페치 조인 (`join fetch`) 쓰자.

`@NamedEntityGraph` 도 사용 가능하다.
엔티티 클래스 위에 정의하고 이름을 통해 사용가능하다.

```java
@NamedEntityGraph(
    name = "Member.all", 
    attributeNodes =@NamedAttributeNode("team")
)
```
```java
@EntityGraph("Member.all")
public List<Member> findNamedEntityGraphByName(String name);
```

### JPA Hint & Lock
JPA 에게 알려주는 힌트 (SQL 힌트가 아니다!!!)

영속성 컨텍스트를 이용한 변경감지 (dirty checking) 을 사용하기 위해서는 객체를 스냅샷을 떠서 비교하게 된다. 그럴 경우 결국 엔티티 하나당 객체를 두개 씩 관리하게 된다. 
이럴때 read-only 인 경우의 유즈케이스를 알고 있으면 `@QueryHints` 를 통해 최적화를 노려볼 수 있다.

```java
@QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
```

Lock 은 `select for update` 기능이다.
```java
@Lock(LockModeType.PESSIMISTIC_WRITE)
List<Member> findByUsername(String name);
```
