### PR TITLE
확장 기능 추가

### DIFF
--- a/src/main/java/study/jpadata/controller/MemberController.java
+++ b/src/main/java/study/jpadata/controller/MemberController.java
@@ -5,6 +5,9 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import study.jpadata.entity.Member;
 import study.jpadata.repository.MemberRepository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -24,5 +27,11 @@ public class MemberController {
     @GetMapping("/api/v2/members/{id}")
     public String getMethodName(@PathVariable("id") Member member) {
         return member.getName();
+    }
+
+    @GetMapping("/api/v1/members")
+    public Page<Member> list(Pageable pageable) {
+        Page<Member> members = memberRepository.findAll(pageable);
+        return members;
     }
 }

--- a/src/main/java/study/jpadata/controller/MemberController.java
+++ b/src/main/java/study/jpadata/controller/MemberController.java
@@ -1,0 +1,28 @@
+package study.jpadata.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import study.jpadata.entity.Member;
+import study.jpadata.repository.MemberRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/api/v1/members/{id}")
+    public String getMemberName(@PathVariable("id") Long id) {
+        Member member = memberRepository.findById(id).get();
+        return member.getName();
+    }
+
+    @GetMapping("/api/v2/members/{id}")
+    public String getMethodName(@PathVariable("id") Member member) {
+        return member.getName();
+    }
+}

--- a/src/main/java/study/jpadata/controller/MemberController.java
+++ b/src/main/java/study/jpadata/controller/MemberController.java
@@ -3,6 +3,7 @@ package study.jpadata.controller;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import study.jpadata.dto.MemberDto;
 import study.jpadata.entity.Member;
 import study.jpadata.repository.MemberRepository;
 
@@ -33,5 +34,12 @@ public class MemberController {
     public Page<Member> list(Pageable pageable) {
         Page<Member> members = memberRepository.findAll(pageable);
         return members;
+    }
+
+    @GetMapping("/api/v2/members")
+    public Page<MemberDto> listV2(Pageable pageable) {
+        Page<Member> members = memberRepository.findAll(pageable);
+        Page<MemberDto> membersDto = members.map(MemberDto::new);
+        return membersDto;
     }
 }

--- a/src/main/java/study/jpadata/dto/MemberDto.java
+++ b/src/main/java/study/jpadata/dto/MemberDto.java
@@ -1,0 +1,15 @@
+package study.jpadata.dto;
+
+import lombok.Data;
+import study.jpadata.entity.Member;
+
+@Data
+public class MemberDto {
+    private Long id;
+    private String username;
+
+    public MemberDto(Member m) {
+        this.id = m.getId();
+        this.username = m.getName();
+    }
+}

--- a/src/main/java/study/jpadata/entity/AuditFields.java
+++ b/src/main/java/study/jpadata/entity/AuditFields.java
@@ -1,0 +1,31 @@
+package study.jpadata.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+public class AuditFields {
+    
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        createdDate = now;
+        updatedDate = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        LocalDateTime now = LocalDateTime.now();
+        updatedDate = now;
+    }
+}

--- a/src/main/java/study/jpadata/entity/AuditFieldsSpring.java
+++ b/src/main/java/study/jpadata/entity/AuditFieldsSpring.java
@@ -1,0 +1,34 @@
+package study.jpadata.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class AuditFieldsSpring {
+    
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String updatedBy;
+}

--- a/src/main/java/study/jpadata/entity/Member.java
+++ b/src/main/java/study/jpadata/entity/Member.java
@@ -27,7 +27,7 @@ import lombok.ToString;
     name = "Member.all",
     attributeNodes = @NamedAttributeNode("team")
 )
-public class Member {
+public class Member extends AuditFields {
     @Id @GeneratedValue
     @Column(name = "member_id")
     private Long id;

--- a/src/main/java/study/jpadata/repository/MemberRepository.java
+++ b/src/main/java/study/jpadata/repository/MemberRepository.java
@@ -14,7 +14,7 @@ import org.springframework.data.repository.query.Param;
 import jakarta.persistence.QueryHint;
 import study.jpadata.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     
     public List<Member> findByNameAndAgeGreaterThan(String name, int age);
 
@@ -57,5 +57,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         value = {@QueryHint(name = "org.hibernate.readOnly", value = "true")},
         forCounting = true
     )
-Page<Member> findByUsername(String name, Pageable pageable);
+    Page<Member> findByUsername(String name, Pageable pageable);
 }

--- a/src/main/java/study/jpadata/repository/MemberRepositoryCustom.java
+++ b/src/main/java/study/jpadata/repository/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package study.jpadata.repository;
+
+import java.util.List;
+
+import study.jpadata.entity.Member;
+
+public interface MemberRepositoryCustom {
+    public List<Member> findMemberCustom();
+}

--- a/src/main/java/study/jpadata/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/study/jpadata/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,18 @@
+package study.jpadata.repository;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import study.jpadata.entity.Member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+    
+    private final EntityManager em;
+
+    @Override
+    public List<Member> findMemberCustom() {
+        return em.createQuery("select m from Member m", Member.class).getResultList();
+    }
+}

--- a/src/test/java/study/jpadata/entity/MemberTest.java
+++ b/src/test/java/study/jpadata/entity/MemberTest.java
@@ -3,11 +3,13 @@ package study.jpadata.entity;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
+import study.jpadata.repository.MemberRepository;
 
 @SpringBootTest
 public class MemberTest {
@@ -43,5 +45,21 @@ public class MemberTest {
             System.out.println("-> member.team=" + member.getTeam());
         }
     }
-    
+
+    @Test
+    @Transactional
+    public void testAuditFields() throws Exception {
+        Member member = new Member("member1", 10);
+        em.persist(member);
+
+        Thread.sleep(100);
+        member.setName("member2");
+
+        em.flush();
+        em.clear();
+
+        Member findMember = em.find(Member.class, member.getId());
+        System.out.println("findMember.createdDate = " + findMember.getCreatedDate());
+        System.out.println("findMember.updatedDate = " + findMember.getUpdatedDate());
+    }
 }

--- a/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
+++ b/src/test/java/study/jpadata/repository/MemberRepositoryTest.java
@@ -263,4 +263,15 @@ public class MemberRepositoryTest {
         member.setName("member2");
         em.flush(); //Update Query 실행X
     }
+
+    @Test
+    public void findMemberCustom() throws Exception {
+        memberRepository.save(new Member("member1", 10));
+
+        List<Member> findMembers = memberRepository.findMemberCustom();
+
+        assertEquals(1, findMembers.size());
+        assertEquals("member1", findMembers.get(0).getName());
+        assertEquals(10, findMembers.get(0).getAge());
+    }
 }


### PR DESCRIPTION
## 사용자 정의 리포지토리 구현
인터페이스를 정의하고 구현체를 만들고나서 `JpaRepository` 를 상속하는 리포지토리 인터페이스에 추가로 새로 정의한 인터페이스를  상속하게해서 사용자 정의 기능을 추가할 수 있다.

이런식으로 인터페이스
```java
public interface MemberRepositoryCustom {
    List<Member> findMemberCustom();
}
```

구현체
```java
@RequiredArgsConstructor
public class MemberRepositoryImpl implements MemberRepositoryCustom {
    private final EntityManager em;

    @Override
    public List<Member> findMemberCustom() {
        return em.createQuery("select m from Member m").getResultList();
    }
}
```

인터페이스 추가 상속
```java
public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
}
```

이렇게 하면 구현체에서 정의한 메서드를 사용할 수 있다. `QueryDSL` 이나 `SpringJdbcTemplate` 을 사용할때 자주 같이 사용한다.

## Auditing

### Vanilla JPA 사용
`@MappedSuperClass` 를 사용해서 순수 audit 필드만 담고 있는 클래스를 만들어주고 `@PrePersist`, `@PostPersist`, `@PreUpdate`, `@PostUpdate` 주요 이벤트 어노테이션을 이용해서 최초 저장전이나 업데이트 전에 audit 필드값을 지정해주는 메서드를 만들어준다.

### Spring Data JPA 사용
비슷하게 `@MappedSuperClass` 를 사용해서 audit 필드를 담고 있는 클래스를 만들어주고 스프링 데이터 JPA 에서 제공하는 `@CreatedDate`, `@LastModifiedDate`, `@CreatedBy`, `@LastModifiedBy` 어노테이션을 적절히 필드에 달아준다.

`@SpringBootApplication` 클래스에 설정을 더해준다.

등록자, 수정자를 정보를 가져오는 빈을 등록한다.
```java
@Bean
public AuditorAware<String> auditorProvider() {
    return () -> Optional.of(UUID.randomUUID().toString());
}
```
여기서는 랜덤 UUID 를 가져와서 설정해주지만 실제 사용시 보통 세션이나 스프링 시큐리티에서 로그인 사용자 정보를 가져와서 값을 지정해준다.

클래스에 `@EnableJpaAuditing` 어노테이션도 달아준다.

`@EntityListeners(AuditingEntityListener.class)` 를 생략하려면 `META-INF/orm.xml` 에 설정을 추가해야 한다.

## 도메인 클래스 컨버터
도메인 클래스 컨버터를 이용해서 컨트롤러 요청 경로에 전달된 엔티티 ID 값을 이용해 바로 엔티티 객체를 사용할 수 있다.

사용전
```java
@GetMapping("/api/v1/members/{id}")
public String getMemberName(@PathVariable("id") Long id) {
    Member member = memberRepository.findById(id).get();
    return member.getName();
}
```
사용후
```java
@GetMapping("/api/v2/members/{id}")
public String getMethodName(@PathVariable("id") Member member) {
    return member.getName();
}
```

이 방법으로 조회된 엔티티는 단순 조회용으로만 사용해야 한다. 트랜잭션 범위 밖에서 조회되었으므로 변경을 해도 데이터가 반영되지 않는다.

## 페이징과 정렬
컨트롤러 메서드 인자로 바로 `Pageable` 값들을 받을 수 있다.

```java
@GetMapping("/api/v1/members")
public Page<Member> list(Pageable pageable) {
    Page<Member> members = memberRepository.findAll(pageable);
    return members;
}
```

위 경로로 요청 파라미터 예시
```
/members?page=0&size=3&sort=id,desc&sort=username,desc
```

### 글로벌 설정
```
spring.data.web.pageable.default-page-size=20 /# 기본 페이지 사이즈/
spring.data.web.pageable.max-page-size=2000 /# 최대 페이지 사이즈/
```

### 개별 설정
`@PageableDefault` 어노테이션을 사용
```java
@RequestMapping(value = "/members_page", method = RequestMethod.GET)
public String list(@PageableDefault(size = 12, sort = "username", direction = Sort.Direction.DESC) Pageable pageable) {
}
```

### 페이징 정보가 둘 이상이면 접두사로 구분
```java
public String list(
@Qualifier("member") Pageable memberPageable,
@Qualifier("order") Pageable orderPageable,
```

예시
`/members?member_page=0&order_page=1`

### DTO 로 변환
* `map()` 을 사용해서 엔티티를 DTO 로 변환

### Page를 1부터 시작하기
1. Pageable, Page를 파리미터와 응답 값으로 사용히지 않고, 직접 클래스를 만들어서 처리한다
2. spring.data.web.pageable.one-indexed-parameters` 를 `true` 로 설정. `page` 파라미터를 `-1` 처리 할 뿐이어서 몇몇 필드값은 맞지 않아 한계가 있다.